### PR TITLE
docs: add Arch Linux / AUR installation instructions to Quick Start in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ This creates:
 - `web-darwin-amd64` - macOS Intel
 - `web-linux-amd64` - Linux x86_64
 
+### Arch Linux / Manjaro
+
+`web` is available on the Arch User Repository (AUR) as a rolling package:
+
+```bash
+yay -S web-git
+```
+
+This installs the latest development version directly from the upstream repository using the official AUR build script:
+[web-git on AUR](https://aur.archlinux.org/packages/web-git)
+
 ## Usage Examples
 
 ```bash


### PR DESCRIPTION
Adds a short AUR installation example for Arch Linux and Manjaro users in the Quick Start section of the README.md file.
This provides an easy one-command install via yay -S web-git while keeping the existing  installation instructions intact.

No code changes - documentation only.