### PR TITLE
Add go install support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,19 @@ web https://login.example.com \
 - **Form filling** - Automated form interaction with LiveView-aware submissions
 - **Session persistence** - Maintains cookies and authentication across runs with profiles
 
-## Quick Start
+## Installation
+
+### Using go install (Recommended)
+
+If you have Go 1.21+ installed:
+
+```bash
+go install github.com/chrismccord/web@latest
+```
+
+This will install the `web` binary to your `$GOPATH/bin` directory (typically `~/go/bin`). Make sure this directory is in your `PATH`.
+
+### Building from source
 
 1. **Build for current platform**:
    ```bash

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module web
+module github.com/chrismccord/web
 
 go 1.24
 


### PR DESCRIPTION
## Summary
- Updates `go.mod` to declare the correct module path (`github.com/chrismccord/web`) to enable installation via `go install`
- Adds installation section to README with `go install` 
