### PR TITLE
Web as a nix flake including firefox and geckodriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ This creates:
 - `web-darwin-amd64` - macOS Intel
 - `web-linux-amd64` - Linux x86_64
 
+### Nix / NixOS
+
+If you use Nix, you can build and run directly from the flake:
+
+```bash
+# Run directly from GitHub without installing
+nix run github:chrismccord/web -- https://example.com
+
+# Run from local checkout
+nix run . -- https://example.com
+
+# Build the package
+nix build
+
+# Enter development shell (includes Go, Firefox, geckodriver)
+nix develop
+```
+
+The flake provides:
+- **`packages.default`** - The `web` binary with Firefox and geckodriver bundled in PATH
+- **`devShells.default`** - Development environment with all dependencies
+
+This eliminates the need for automatic Firefox/geckodriver downloads since Nix provides them.
+
 ## Usage Examples
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769789167,
+        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "web - portable web scraper for LLMs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        isDarwin = pkgs.stdenv.isDarwin;
+
+        # On macOS, Firefox is an app bundle; create a wrapper script
+        firefoxWrapper = if isDarwin then
+          pkgs.writeShellScriptBin "firefox" ''
+            exec "${pkgs.firefox}/Applications/Firefox.app/Contents/MacOS/firefox" "$@"
+          ''
+        else
+          pkgs.firefox;
+      in
+      {
+        packages.default = pkgs.buildGoModule {
+          pname = "web";
+          version = "0.1.0";
+          src = ./.;
+
+          vendorHash = "sha256-Pc/ZMqesG0bNPAqBnbIkRbJfAmz6NW0JvcQ2kwWpG6M=";
+
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+
+          # Skip tests during build - they require network access and browser
+          # Run tests manually in devShell: go test -v -timeout=300s
+          doCheck = false;
+
+          postInstall = ''
+            wrapProgram $out/bin/web \
+              --prefix PATH : ${pkgs.lib.makeBinPath [ firefoxWrapper pkgs.geckodriver ]}
+          '';
+
+          meta = with pkgs.lib; {
+            description = "Portable web scraper for LLMs with Firefox automation";
+            license = licenses.mit;
+            mainProgram = "web";
+          };
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.go
+            firefoxWrapper
+            pkgs.geckodriver
+          ];
+
+          shellHook = ''
+            echo "web development shell"
+            echo "Firefox:     $(which firefox)"
+            echo "Geckodriver: $(which geckodriver)"
+            echo ""
+            echo "Build:       go build -o web ."
+            echo "Run tests:   go test -v -timeout=300s"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
Afford running web repo as a flake, with nix managing its dependencies.

```
nix run github:chrismccord/web -- https://example.com
```

This is also a prerequisite to adding to the nix package registry https://search.nixos.org/packages